### PR TITLE
Save to out.json instead of out/messages.json

### DIFF
--- a/src/grab.ts
+++ b/src/grab.ts
@@ -45,7 +45,7 @@ const accessToken = process.argv[2];
     }
   }
   const json = JSON.stringify(messages, null, 4);
-  fs.writeFile('./out/messages.json', json, 'utf8', err => {
+  fs.writeFile('./out.json', json, 'utf8', err => {
     console.log(err);
   });
 })();


### PR DESCRIPTION
Two reasons:
- this matches the behavior described in the README
- if the directory `out/` does not exist, like when the repo is just cloned, the script will download all messages (potentially taking a long time) then fail since it can't create the destination file.